### PR TITLE
Pin GitHub Actions to specific SHAs (4 actions in 1 files)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,10 +19,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4
       
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # actions/setup-python@v4
       with:
         python-version: '3.11'
         
@@ -35,7 +35,7 @@ jobs:
       run: mkdocs build --verbose --clean --strict
       
     - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # actions/upload-pages-artifact@v3
       with:
         path: ./site
 
@@ -46,4 +46,4 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # actions/deploy-pages@v4


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 4

### 📝 Changes by file

#### `.github/workflows/deploy-docs.yml`

- 📌 `actions/checkout@v4` → `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # actions/checkout@v4`
- 📌 `actions/setup-python@v4` → `actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # actions/setup-python@v4`
- 📌 `actions/upload-pages-artifact@v3` → `actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # actions/upload-pages-artifact@v3`
- 📌 `actions/deploy-pages@v4` → `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # actions/deploy-pages@v4`

